### PR TITLE
Fix/YOLO pose export fixes

### DIFF
--- a/dagshub_annotation_converter/image/exporters/yolo.py
+++ b/dagshub_annotation_converter/image/exporters/yolo.py
@@ -25,17 +25,30 @@ logger = logging.getLogger(__name__)
 
 class YoloExporterStrategy:
     @abstractmethod
-    def get_yolo_yaml(self, project: AnnotationProject, data_dir: Path, image_dir_name: str) -> str:
+    def get_yolo_yaml(
+        self,
+        project: AnnotationProject,
+        data_dir: Path,
+        image_dir_name: str,
+        label_dir_name: str,
+        **kwargs,
+    ) -> str:
         """Gets the contents of the YOLO metadata yaml file"""
         ...
 
     @abstractmethod
-    def convert_file(self, project: AnnotationProject, f: AnnotatedFile) -> str:
+    def convert_file(self, project: AnnotationProject, f: AnnotatedFile, **kwargs) -> str:
         """Converts annotations for a single file into a yolo annotation and returns the content"""
         ...
 
-    def generate_generic_yaml_content(self, project: AnnotationProject, data_dir: Path, image_dir_name: str) -> dict:
-        train, val = self.determine_test_and_val_folders(data_dir, image_dir_name)
+    def generate_generic_yaml_content(
+        self,
+        project: AnnotationProject,
+        data_dir: Path,
+        image_dir_name: str,
+        label_dir_name: str,
+    ) -> dict:
+        train, val = self.determine_test_and_val_folders(data_dir, image_dir_name, label_dir_name)
         yaml_structure = {
             "path": str(data_dir.absolute()),
             "names": {cat.id: cat.name for cat in project.categories.categories},
@@ -45,25 +58,34 @@ class YoloExporterStrategy:
         }
         return yaml_structure
 
-    def determine_test_and_val_folders(self, data_dir: Path, image_dir_name: str) -> tuple[str, str]:
+    @staticmethod
+    def determine_test_and_val_folders(data_dir: Path, image_dir_name: str, label_dir_name: str) -> tuple[str, str]:
         """
         Tries to find test and val folder.
         Current logic:
-        1) Drill down in data_dir until an image directory is found
-        2) Then look at the subfolders of the image dir
+        1) Drill down in data_dir until a label directory is found
+        2) Then look at the subfolders of the label dir
             If there's 0/1/more than 2 dirs - make the data dir both the test and val dir
             If there are two dirs and one contains train/one contains val, the other gets assigned accordingly
 
         """
-        img_dir = None
+        label_dir = None
         for root, dirs, files in os.walk(data_dir):
-            if image_dir_name in dirs:
-                img_dir = Path(root) / image_dir_name
-        if img_dir is None:
-            raise RuntimeError(f'Could not find the image dir named "{image_dir_name}" in the data directory')
-        subdirs = [img_dir / p for p in os.listdir(img_dir)]
+            if label_dir_name in dirs:
+                label_dir = Path(root) / label_dir_name
+        if label_dir is None:
+            raise RuntimeError(f'Could not find the label dir named "{label_dir_name}" in the data directory')
+        subdirs = [label_dir / p for p in os.listdir(label_dir)]
         subdirs = [p for p in subdirs if p.is_dir()]
 
+        # Replace the label -> image
+        img_dir_parts = list(label_dir.parts)
+        for i, part in enumerate(reversed(label_dir.parts)):
+            if part == label_dir_name:
+                img_dir_parts[len(img_dir_parts) - i - 1] = image_dir_name
+                break
+
+        img_dir = Path(*img_dir_parts)
         img_dir_relative = img_dir.relative_to(data_dir)
 
         if len(subdirs) != 2:
@@ -80,10 +102,12 @@ class YoloExporterStrategy:
 
 
 class BBoxExporterStrategy(YoloExporterStrategy):
-    def get_yolo_yaml(self, project: AnnotationProject, data_dir: Path, image_dir_name: str) -> str:
-        return yaml.dump(self.generate_generic_yaml_content(project, data_dir, image_dir_name))
+    def get_yolo_yaml(
+        self, project: AnnotationProject, data_dir: Path, image_dir_name: str, label_dir_name: str, **kwargs
+    ) -> str:
+        return yaml.dump(self.generate_generic_yaml_content(project, data_dir, image_dir_name, label_dir_name))
 
-    def convert_file(self, project: AnnotationProject, f: AnnotatedFile) -> str:
+    def convert_file(self, project: AnnotationProject, f: AnnotatedFile, **kwargs) -> str:
         wrong_annotation_counter = 0
         res = ""
         for ann in f.annotations:
@@ -101,10 +125,17 @@ class BBoxExporterStrategy(YoloExporterStrategy):
 
 
 class SegmentationExporterStrategy(YoloExporterStrategy):
-    def get_yolo_yaml(self, project: AnnotationProject, data_dir: Path, image_dir_name: str) -> str:
-        return yaml.dump(self.generate_generic_yaml_content(project, data_dir, image_dir_name))
+    def get_yolo_yaml(
+        self,
+        project: AnnotationProject,
+        data_dir: Path,
+        image_dir_name: str,
+        label_dir_name: str,
+        **kwargs,
+    ) -> str:
+        return yaml.dump(self.generate_generic_yaml_content(project, data_dir, image_dir_name, label_dir_name))
 
-    def convert_file(self, project: AnnotationProject, f: AnnotatedFile) -> str:
+    def convert_file(self, project: AnnotationProject, f: AnnotatedFile, **kwargs) -> str:
         wrong_annotation_counter = 0
         res = ""
         for ann in f.annotations:
@@ -122,17 +153,19 @@ class SegmentationExporterStrategy(YoloExporterStrategy):
 
 
 class PoseExporterStrategy(YoloExporterStrategy):
-    def get_yolo_yaml(self, project: AnnotationProject, data_dir: Path, image_dir_name: str) -> str:
-        yaml_dict = self.generate_generic_yaml_content(project, data_dir, image_dir_name)
+    def get_yolo_yaml(
+        self, project: AnnotationProject, data_dir: Path, image_dir_name: str, label_dir_name: str, **kwargs
+    ) -> str:
+        yaml_dict = self.generate_generic_yaml_content(project, data_dir, image_dir_name, label_dir_name)
         if len(project.pose_config.pose_points) == 0:
             project.regenerate_pose_points()
 
         max_points = project.pose_config.bind_pose_points_to_max()
 
-        yaml_dict["kpt_shape"] = [max_points, 3]
+        yaml_dict["kpt_shape"] = [max_points, kwargs.get("keypoint_dim", 3)]
         return yaml.dump(yaml_dict)
 
-    def convert_file(self, project: AnnotationProject, f: AnnotatedFile):
+    def convert_file(self, project: AnnotationProject, f: AnnotatedFile, **kwargs):
         # For pose: validate that the amount of points is equal across all annotations, otherwise don't import
         # Need poses to be consistent
         wrong_annotation_counter = 0
@@ -152,7 +185,14 @@ class PoseExporterStrategy(YoloExporterStrategy):
             if len(points) < category_n_points:
                 delta = category_n_points - len(points)
                 points.extend([KeyPoint(x=0.0, y=0.0, is_visible=False)] * delta)
-            res += " ".join([f"{p.x} {p.y} {1 if p.is_visible or p.is_visible is None else 0}" for p in points])
+            points_output = ""
+            for p in points:
+                points_output += f" {p.x} {p.y} "
+                if kwargs.get("keypoint_dim", 3) == 3:
+                    points_output += "1 " if p.is_visible or p.is_visible is None else "0 "
+                points_output = points_output.strip()
+            res += points_output
+            res += "\n"
         if wrong_annotation_counter != 0:
             logger.warning(f"Skipped {wrong_annotation_counter} non-pose annotation(s) for file {f.file}")
         return res
@@ -167,12 +207,28 @@ class YoloExporter:
         label_dir_name: str = "labels",
         label_extension: str = ".txt",
         meta_file: Union[str, PathLike] = "annotations.yaml",
+        overwrite_existing_meta_file: bool = True,
+        pose_keypoint_dim: Literal[2, 3] = 3,
     ):
+        """
+        Export annotations to YOLO format
+        :param data_dir: path to the directory where to store the labels
+        :param annotation_type: Type of annotations to export. Either bbox, segmentation, or pose
+        :param image_dir_name: Name of the image directory. Default is images
+        :param label_dir_name: Name of the label directory. Default is labels
+        :param label_extension: Extension to use on the label files. Default is .txt
+        :param meta_file: Path of the YOLO .yaml file that will be written
+        :param overwrite_existing_meta_file: If this is set to True, existing meta file wouldn't be overwritten.
+            Be cautious, this might cause category mismatches, if the data has changed!
+        :param pose_keypoint_dim: For pose annotations - dimensions of a keypoint. Either 2 or 3, 3 by default
+        """
         self.data_dir = Path(data_dir)
         self.image_dir_name = image_dir_name
         self.label_dir_name = label_dir_name
         self.meta_file = meta_file
         self.label_extension = label_extension
+        self.overwrite_existing_meta_file = overwrite_existing_meta_file
+        self.pose_keypoint_dim = pose_keypoint_dim
         if not self.label_extension.startswith("."):
             self.label_extension = "." + self.label_extension
 
@@ -195,7 +251,7 @@ class YoloExporter:
     def export(self, project: AnnotationProject):
         # Write the annotations
         for annotated in project.files:
-            converted = self.strategy.convert_file(project, annotated)
+            converted = self.strategy.convert_file(project, annotated, keypoint_dim=self.pose_keypoint_dim)
             if not converted:
                 logger.warning(f"No annotations of fitting type found for file {annotated.file}")
                 continue
@@ -207,10 +263,23 @@ class YoloExporter:
             annotation_file_path.write_text(converted)
 
         # Write the metadata file
-        Path(self.meta_file).parent.mkdir(parents=True, exist_ok=True)
-        with open(self.meta_file, "w") as f:
-            dt_now = datetime.datetime.now()
-            f.write(
-                f"# This YOLO dataset was autogenerated by DagsHub annotation converter on {dt_now.isoformat()}\n\n"
-            )
-            f.write(self.strategy.get_yolo_yaml(project, self.data_dir, self.image_dir_name))
+        meta_file_path = Path(self.meta_file)
+        meta_file_path.parent.mkdir(parents=True, exist_ok=True)
+        if meta_file_path.exists() and not self.overwrite_existing_meta_file:
+            logger.warning(f"Not overwriting existing YOLO config {self.meta_file}")
+        else:
+            with open(self.meta_file, "w") as f:
+                dt_now = datetime.datetime.now()
+                f.write(
+                    f"# This YOLO dataset was autogenerated by DagsHub annotation converter on {dt_now.isoformat()}\n\n"
+                )
+                f.write(
+                    self.strategy.get_yolo_yaml(
+                        project,
+                        self.data_dir,
+                        self.image_dir_name,
+                        self.label_dir_name,
+                        keypoint_dim=self.pose_keypoint_dim,
+                    )
+                )
+                logger.warning(f"Written out the YOLO config to {self.meta_file}")

--- a/dagshub_annotation_converter/image/util/path_util.py
+++ b/dagshub_annotation_converter/image/util/path_util.py
@@ -1,6 +1,19 @@
 from pathlib import Path
 
 
+class YoloImageDirNotFoundError(Exception):
+    def __init__(self, img_path: Path, image_dir_name: str):
+        super().__init__()
+        self.img_path = img_path
+        self.image_dir_name = image_dir_name
+
+    def __str__(self):
+        return (
+            f'Could not find the image dir "{self.image_dir_name}" in path "{self.img_path}".\n'
+            f"Make sure your image_dir_name variable is configured correctly"
+        )
+
+
 def get_extension(path: Path) -> str:
     name = path.name
     ext_dot_index = name.rfind(".")
@@ -17,6 +30,9 @@ def yolo_img_path_to_label_path(
     for i, part in enumerate(reversed(img_path.parts)):
         if part == image_dir_name:
             new_parts[len(new_parts) - i - 1] = label_dir_name
+            break
+    else:
+        raise YoloImageDirNotFoundError(img_path, image_dir_name)
 
     # Replace the extension
     new_parts[-1] = new_parts[-1].replace(get_extension(img_path), label_extension)

--- a/dagshub_annotation_converter/schema/ir/annotation_ir.py
+++ b/dagshub_annotation_converter/schema/ir/annotation_ir.py
@@ -280,6 +280,12 @@ class YoloImportConfig(BaseModel):
     keypoint_shape: Literal[2, 3] = 2
 
 
+class YoloExportConfig(BaseModel):
+    keypoint_dim: Literal[2, 3] = 3  # Export with 3 dimensions by default
+    rewrite_yaml: bool = True
+    """Whether to rewrite the YAML file or not if it already exists"""
+
+
 class ImportConfig(BaseModel):
     yolo: YoloImportConfig = YoloImportConfig()
 


### PR DESCRIPTION
Fixes in this PR:
- Allow for exporting 2-dimensional poses
- Add a flag to not overwrite the yaml file
- Fix newline problem with poses, where all data was written out in one line
- Raise error on incorrect image_dir_name configuration