### PR TITLE
YOLO Export: Use absolute data path + guess train/val/test directories

### DIFF
--- a/dagshub_annotation_converter/formats/yolo/context.py
+++ b/dagshub_annotation_converter/formats/yolo/context.py
@@ -39,6 +39,8 @@ class YoloContext(ParentModel):
     """Path to the train data, relative to the base path"""
     val_path: Optional[Path] = Path(".")
     """Path to the validation data, relative to the base path"""
+    test_path: Optional[Path] = None
+    """Path to the test data, relative to the base path (defaults to None, might be discovered)"""
 
     @staticmethod
     def from_yaml_file(file_path: Union[str, Path], annotation_type: YoloAnnotationTypes) -> "YoloContext":
@@ -59,6 +61,8 @@ class YoloContext(ParentModel):
             res.train_path = Path(meta_dict["train"])
         if "val" in meta_dict:
             res.val_path = Path(meta_dict["val"])
+        if "test" in meta_dict:
+            res.test_path = Path(meta_dict["test"])
 
         return res
 
@@ -81,7 +85,7 @@ class YoloContext(ParentModel):
             )
 
         content = {
-            "path": str(path),
+            "path": str(path.resolve()),
             "names": {cat.id: cat.name for cat in self.categories.categories},
             "nc": len(self.categories),
         }
@@ -90,6 +94,8 @@ class YoloContext(ParentModel):
             content["train"] = str(self.train_path)
         if self.val_path is not None:
             content["val"] = str(self.val_path)
+        if self.test_path is not None:
+            content["test"] = str(self.test_path)
 
         if self.annotation_type == "pose":
             if self.keypoints_in_annotation is None:


### PR DESCRIPTION
YOLO training assumes that if `path` in the .yaml is set to a relative path, then the folder is determined not relative to the yaml file, but with some additional logic.

Instead of trying to satisfy that, I'm changing the output so that the path variable in the yaml is always set to absolute. That way the training can work.

Also I'm now trying to guess train/test/val paths