### PR TITLE
Fix missing filename in _reimport_poses

### DIFF
--- a/dagshub_annotation_converter/formats/label_studio/task.py
+++ b/dagshub_annotation_converter/formats/label_studio/task.py
@@ -143,6 +143,7 @@ class LabelStudioTask(ParentModel):
             category: Optional[str] = None
             image_width: Optional[int] = None
             image_height: Optional[int] = None
+            filename: Optional[str] = None
             if maybe_bbox is None:
                 logger.warning(
                     f"Bounding box of pose with annotation ID {bbox_id} "
@@ -155,6 +156,7 @@ class LabelStudioTask(ParentModel):
                 category = bbox.ensure_has_one_category()
                 image_height = bbox.image_height
                 image_width = bbox.image_width
+                filename = bbox.filename
                 annotations_to_remove.add(bbox_id)
             # Fetch the points
             points: List[IRPosePoint] = []
@@ -176,6 +178,8 @@ class LabelStudioTask(ParentModel):
                         image_width = maybe_point.image_width
                     if image_height is None:
                         image_height = maybe_point.image_height
+                    if filename is None:
+                        filename = maybe_point.filename
                     points.extend(maybe_point.points)
                     annotations_to_remove.add(point_id)
 
@@ -193,6 +197,7 @@ class LabelStudioTask(ParentModel):
                 coordinate_style=CoordinateStyle.NORMALIZED,
                 image_width=image_width,
                 image_height=image_height,
+                filename=filename,
             )
             if bbox is not None:
                 sum_annotation.width = bbox.width


### PR DESCRIPTION
To reproduce the issue, you need some datapoints annotated with pose data, and run something like the following snippet:

```python
from dagshub.data_engine import datasources
ds = datasources.get("owner/repo", "datasource-name")
ds["cvat_annotation"].is_not_null().head(1).export_as_yolo(
    download_dir="bla",
    annotation_field="cvat_annotation",
    annotation_type="pose",
)
```