### PR TITLE
Bug: Autogenerate kpt_shape when exporting pose annotations to YOLO, even if the shape wasn't specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ dist/
 
 .DS_Store
 .idea/
+.vscode/
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ scratches/
 *.env
 dist/
 .coverage*
+
+.DS_Store
+.idea/
+__pycache__/

--- a/dagshub_annotation_converter/converters/yolo.py
+++ b/dagshub_annotation_converter/converters/yolo.py
@@ -208,20 +208,7 @@ def export_to_fs(
 
     # For pose annotations, if the number of keypoints is not set, guess it from the passed annotations
     if context.annotation_type == "pose" and context.keypoints_in_annotation is None:
-        max_keypoints = 0
-        for anns in grouped_annotations.values():
-            for ann in anns:
-                if isinstance(ann, IRPoseImageAnnotation):
-                    current_keypoints = len(ann.points)
-                    if current_keypoints > max_keypoints:
-                        if max_keypoints > 0:
-                            logger.warning(
-                                f"Found annotation with {current_keypoints} keypoints, "
-                                f"which is more than previously found maximum of {max_keypoints}.\n"
-                                "Your annotations might be inconsistent."
-                            )
-                        max_keypoints = current_keypoints
-        context.keypoints_in_annotation = max_keypoints
+        context.infer_keypoints_from_annotations(annotations)
 
     yaml_file_path = export_path / meta_file
     with open(yaml_file_path, "w") as yaml_f:

--- a/dagshub_annotation_converter/converters/yolo.py
+++ b/dagshub_annotation_converter/converters/yolo.py
@@ -13,7 +13,7 @@ from dagshub_annotation_converter.formats.yolo import (
     import_lookup,
     YoloAnnotationTypes,
 )
-from dagshub_annotation_converter.ir.image import IRImageAnnotationBase, IRPoseImageAnnotation
+from dagshub_annotation_converter.ir.image import IRImageAnnotationBase
 from dagshub_annotation_converter.util import is_image, replace_folder
 
 logger = logging.getLogger(__name__)

--- a/tests/fs_export/yolo/test_fs_export.py
+++ b/tests/fs_export/yolo/test_fs_export.py
@@ -211,3 +211,42 @@ def test_export_with_image_in_path(tmp_path):
     assert (tmp_path / "yolo_dagshub.yaml").exists()
     assert (tmp_path / "data" / "labels" / "cats" / "1.txt").exists()
     assert (tmp_path / "data" / "labels" / "dogs" / "2.txt").exists()
+
+
+def test_pose_export_point(tmp_path):
+    ctx = YoloContext(annotation_type="pose", path=Path("data"))
+    ctx.categories.add(name="person")
+    annotations = [
+        IRPoseImageAnnotation.from_points(
+            filename="images/people/1.jpg",
+            categories={"person": 1.0},
+            points=[
+                IRPosePoint(x=0.1, y=0.1, visibility=2),
+                IRPosePoint(x=0.2, y=0.2, visibility=2),
+                IRPosePoint(x=0.3, y=0.3, visibility=2),
+            ],
+            image_width=100,
+            image_height=200,
+            coordinate_style=CoordinateStyle.NORMALIZED,
+        ),
+        IRPoseImageAnnotation.from_points(
+            filename="images/people/2.jpg",
+            categories={"person": 1.0},
+            points=[
+                IRPosePoint(x=0.4, y=0.4, visibility=2),
+                IRPosePoint(x=0.5, y=0.5, visibility=2),
+                IRPosePoint(x=0.6, y=0.6, visibility=2),
+            ],
+            image_width=100,
+            image_height=200,
+            coordinate_style=CoordinateStyle.NORMALIZED,
+        ),
+    ]
+
+    p = export_to_fs(ctx, annotations, export_dir=tmp_path)
+
+    assert ctx.keypoints_in_annotation == 3  # Should be inferred from the annotations
+    assert p == tmp_path / "yolo_dagshub.yaml"
+    assert (tmp_path / "yolo_dagshub.yaml").exists()
+    assert (tmp_path / "data" / "labels" / "people" / "1.txt").exists()
+    assert (tmp_path / "data" / "labels" / "people" / "2.txt").exists()


### PR DESCRIPTION
When exporting pose annotations to YOLO, the context might not have the `keypoints_in_annotations` value set, which will make the YAML generation fail.
The number of keypoints can actually be inferred from the annotations passed to `export_to_fs`, so we're going to be doing that now