### PR TITLE
Bug: Empty annotation files crash yolo filesystem import

### DIFF
--- a/dagshub_annotation_converter/converters/yolo.py
+++ b/dagshub_annotation_converter/converters/yolo.py
@@ -52,7 +52,9 @@ def load_yolo_from_fs_with_context(
             if not annotation.exists():
                 logger.warning(f"Couldn't find annotation file [{annotation}] for image file [{img}]")
                 continue
-            annotations[str(relpath)] = parse_annotation(context, data_dir_path, img, annotation)
+            parsed_annotations = parse_annotation(context, data_dir_path, img, annotation)
+            if len(parsed_annotations) > 0:
+                annotations[str(relpath)] = parse_annotation(context, data_dir_path, img, annotation)
 
     return annotations
 
@@ -63,7 +65,7 @@ def parse_annotation(
     img = PIL.Image.open(img_path)
     img_width, img_height = img.size
 
-    annotation_strings = annotation_path.read_text().strip().split("\n")
+    annotation_strings = [ann for ann in annotation_path.read_text().strip().split("\n") if ann]
 
     assert context.annotation_type is not None
 

--- a/tests/fs_import/yolo/test_fs_import.py
+++ b/tests/fs_import/yolo/test_fs_import.py
@@ -181,3 +181,11 @@ def test_pose_3dim(data_folder, img_path):
     expected = generate_expected(img_path, ctx, to_keypoints)
 
     assert annotations == expected
+
+
+def test_empty_annotation(data_folder):
+    yaml = data_folder / "pose_2dim.yaml"
+
+    annotations, ctx = load_yolo_from_fs("pose", yaml, label_dir_name="empty")
+
+    assert annotations == {}


### PR DESCRIPTION
## Spec 
Bug appears when running `load_yolo_from_fs()` on a project that might have a file text for annotations, that is empty (no annotations).

## Testing
Added an integration test that checks this specific case. Was failing before this PR