### PR TITLE
Add COCO to DagsHub annotation converter.

### DIFF
--- a/dagshub_annotation_converter/converters/__init__.py
+++ b/dagshub_annotation_converter/converters/__init__.py
@@ -1,0 +1,1 @@
+from .coco import convert_coco_json_to_ir

--- a/dagshub_annotation_converter/converters/coco.py
+++ b/dagshub_annotation_converter/converters/coco.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+from typing import Union, List, Dict, Tuple
+
+from dagshub_annotation_converter.formats.coco.annotations import COCODataset, COCOAnnotation, COCOImage, COCOCategory
+from dagshub_annotation_converter.formats.coco.importer import import_coco
+from dagshub_annotation_converter.ir.image import IRBBoxImageAnnotation, CoordinateStyle, IRImageAnnotation
+
+def coco_to_ir(coco_dataset: COCODataset) -> List[IRImageAnnotation]:
+    """
+    Converts a COCODataset object to a list of IRImageAnnotation objects.
+    """
+    ir_annotations: List[IRImageAnnotation] = []
+    
+    # Create a mapping from image_id to COCOImage object for quick lookup
+    images_map: Dict[int, COCOImage] = {image.id: image for image in coco_dataset.images}
+    
+    # Create a mapping from category_id to COCOCategory object for quick lookup
+    categories_map: Dict[int, COCOCategory] = {category.id: category for category in coco_dataset.categories}
+
+    for ann in coco_dataset.annotations:
+        image_info = images_map.get(ann.image_id)
+        category_info = categories_map.get(ann.category_id)
+
+        if image_info is None:
+            # Log or handle missing image info
+            print(f"Warning: Image with ID {ann.image_id} not found for annotation ID {ann.id}")
+            continue
+        
+        if category_info is None:
+            # Log or handle missing category info
+            print(f"Warning: Category with ID {ann.category_id} not found for annotation ID {ann.id}")
+            continue
+
+        # COCO bbox is [x, y, width, height]
+        # IR is top, left, width, height
+        x, y, width, height = ann.bbox
+        
+        # Assuming the IR uses the actual pixel values (denormalized)
+        # and the origin is top-left.
+        ir_bbox = IRBBoxImageAnnotation(
+            categories={category_info.name: 1.0}, # Assuming single category with confidence 1.0
+            top=y,
+            left=x,
+            width=width,
+            height=height,
+            rotation=0.0, # COCO bbox format doesn't typically include rotation
+            image_width=image_info.width,
+            image_height=image_info.height,
+            filename=image_info.file_name,
+            coordinate_style=CoordinateStyle.DENORMALIZED,
+            imported_id=str(ann.id)
+        )
+        ir_annotations.append(ir_bbox)
+        
+    return ir_annotations
+
+def convert_coco_json_to_ir(file_path: Union[str, Path]) -> List[IRImageAnnotation]:
+    """
+    Loads a COCO JSON annotation file and converts it to a list of IRImageAnnotation objects.
+    """
+    coco_dataset = import_coco(file_path)
+    return coco_to_ir(coco_dataset)

--- a/dagshub_annotation_converter/formats/__init__.py
+++ b/dagshub_annotation_converter/formats/__init__.py
@@ -1,0 +1,2 @@
+from .coco.annotations import COCODataset
+from .coco.importer import import_coco

--- a/dagshub_annotation_converter/formats/coco/__init__.py
+++ b/dagshub_annotation_converter/formats/coco/__init__.py
@@ -1,0 +1,1 @@
+# This can be initially empty

--- a/dagshub_annotation_converter/formats/coco/annotations.py
+++ b/dagshub_annotation_converter/formats/coco/annotations.py
@@ -1,0 +1,33 @@
+from typing import List, Dict, Any
+from pydantic import BaseModel
+
+class COCOImage(BaseModel):
+    id: int
+    width: int
+    height: int
+    file_name: str
+    license: int = 0
+    flickr_url: str = ""
+    coco_url: str = ""
+    date_captured: str = ""
+
+class COCOCategory(BaseModel):
+    id: int
+    name: str
+    supercategory: str = ""
+
+class COCOAnnotation(BaseModel):
+    id: int
+    image_id: int
+    category_id: int
+    segmentation: List[List[float]] = [] # For polygons or RLE
+    area: float
+    bbox: List[float] # [x, y, width, height]
+    iscrowd: int # 0 or 1
+
+class COCODataset(BaseModel):
+    info: Dict[str, Any] = {}
+    licenses: List[Dict[str, Any]] = []
+    images: List[COCOImage]
+    annotations: List[COCOAnnotation]
+    categories: List[COCOCategory]

--- a/dagshub_annotation_converter/formats/coco/importer.py
+++ b/dagshub_annotation_converter/formats/coco/importer.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+from typing import Union
+from .annotations import COCODataset
+
+def DagsHubDataset(COCODataset): # Placeholder for DagsHub's dataset structure
+    pass
+
+def import_coco(file_path: Union[str, Path]) -> COCODataset:
+    """
+    Loads COCO annotations from a JSON file.
+    """
+    with open(file_path, 'r') as f:
+        data = json.load(f)
+    return COCODataset(**data)
+
+def convert_coco_to_dagshub(coco_dataset: COCODataset) -> DagsHubDataset: # Placeholder for DagsHub's dataset structure
+    """
+    Converts COCO dataset to DagsHub dataset.
+    (This will be implemented in more detail in the converter step)
+    """
+    # For now, just a placeholder
+    print(f"Converting {len(coco_dataset.images)} images and {len(coco_dataset.annotations)} annotations.")
+    # Actual conversion logic will go into the converter module later
+    return DagsHubDataset() # Placeholder for DagsHub's dataset structure

--- a/tests/coco/sample_coco_annotations.json
+++ b/tests/coco/sample_coco_annotations.json
@@ -1,0 +1,39 @@
+{
+    "info": {
+        "description": "Sample COCO Dataset for Testing",
+        "version": "1.0",
+        "year": 2023,
+        "date_created": "2023/10/27"
+    },
+    "licenses": [],
+    "images": [
+        {
+            "id": 1,
+            "width": 800,
+            "height": 600,
+            "file_name": "test_image.jpg",
+            "license": 0,
+            "flickr_url": "",
+            "coco_url": "",
+            "date_captured": ""
+        }
+    ],
+    "categories": [
+        {
+            "id": 1,
+            "name": "cat",
+            "supercategory": "animal"
+        }
+    ],
+    "annotations": [
+        {
+            "id": 1,
+            "image_id": 1,
+            "category_id": 1,
+            "segmentation": [],
+            "area": 6000.0,
+            "bbox": [100, 100, 200, 300], 
+            "iscrowd": 0
+        }
+    ]
+}

--- a/tests/coco/test_coco_converter.py
+++ b/tests/coco/test_coco_converter.py
@@ -1,0 +1,39 @@
+import pytest
+from pathlib import Path
+from dagshub_annotation_converter.converters.coco import convert_coco_json_to_ir
+from dagshub_annotation_converter.ir.image import IRBBoxImageAnnotation, CoordinateStyle
+
+# Get the directory of the current test file
+TEST_DIR = Path(__file__).parent
+
+def test_convert_sample_coco_to_ir():
+    sample_file = TEST_DIR / "sample_coco_annotations.json"
+    ir_annotations = convert_coco_json_to_ir(sample_file)
+
+    assert len(ir_annotations) == 1
+    
+    ann = ir_annotations[0]
+    assert isinstance(ann, IRBBoxImageAnnotation)
+    
+    # Verify categories (name comes from categories map, confidence is default 1.0)
+    assert "cat" in ann.categories
+    assert ann.categories["cat"] == 1.0
+    
+    # Verify bounding box coordinates (COCO: [x, y, width, height])
+    # IR: top=y, left=x, width=width, height=height
+    assert ann.left == 100
+    assert ann.top == 100
+    assert ann.width == 200
+    assert ann.height == 300
+    
+    assert ann.rotation == 0.0 # Default, as COCO bbox has no rotation
+    
+    # Verify image information
+    assert ann.image_width == 800
+    assert ann.image_height == 600
+    assert ann.filename == "test_image.jpg"
+    
+    assert ann.coordinate_style == CoordinateStyle.DENORMALIZED
+    
+    # Verify imported ID (should be string representation of annotation ID)
+    assert ann.imported_id == "1"


### PR DESCRIPTION
This change introduces a new converter to transform annotations from the COCO (Common Objects in Context) format to the DagsHub Intermediate Representation (IR).

Key changes:
- Defines Pydantic models for the COCO annotation structure under `dagshub_annotation_converter/formats/coco/`.
- Implements a converter in `dagshub_annotation_converter/converters/coco.py` that maps COCO bounding box annotations to `IRBBoxImageAnnotation` objects.
- Integrates the new format and converter into the main package by updating relevant `__init__.py` files.
- Adds unit tests with a sample COCO annotation file in `tests/coco/` to validate the converter's output.

This converter currently supports bounding box annotations. Future work could extend it to handle other COCO annotation types like segmentation and keypoints.