### PR TITLE
Bug: [Label Studio] Importing a pose with a single keypoint adds a redundant BBox to the LS task

### DIFF
--- a/dagshub_annotation_converter/formats/label_studio/keypointlabels.py
+++ b/dagshub_annotation_converter/formats/label_studio/keypointlabels.py
@@ -43,21 +43,25 @@ class KeyPointLabelsAnnotation(ImageAnnotationResultABC):
         ir_annotation = ir_annotation.normalized()
         category = ir_annotation.ensure_has_one_category()
 
-        bbox = RectangleLabelsAnnotation(
-            original_width=ir_annotation.image_width,
-            original_height=ir_annotation.image_height,
-            value=RectangleLabelsAnnotationValue(
-                x=ir_annotation.left * 100,
-                y=ir_annotation.top * 100,
-                width=ir_annotation.width * 100,
-                height=ir_annotation.height * 100,
-                rectanglelabels=[category],
-            ),
-        )
+        res: List[ImageAnnotationResultABC] = []
 
-        points = []
+        # For poses (multiple points) - add a bounding box
+        if len(ir_annotation.points) > 1:
+            bbox = RectangleLabelsAnnotation(
+                original_width=ir_annotation.image_width,
+                original_height=ir_annotation.image_height,
+                value=RectangleLabelsAnnotationValue(
+                    x=ir_annotation.left * 100,
+                    y=ir_annotation.top * 100,
+                    width=ir_annotation.width * 100,
+                    height=ir_annotation.height * 100,
+                    rectanglelabels=[category],
+                ),
+            )
+            res.append(bbox)
+
         for point in ir_annotation.points:
-            points.append(
+            res.append(
                 KeyPointLabelsAnnotation(
                     original_width=ir_annotation.image_width,
                     original_height=ir_annotation.image_height,
@@ -69,4 +73,4 @@ class KeyPointLabelsAnnotation(ImageAnnotationResultABC):
                 )
             )
 
-        return [bbox, *points]
+        return res

--- a/dagshub_annotation_converter/formats/label_studio/task.py
+++ b/dagshub_annotation_converter/formats/label_studio/task.py
@@ -225,7 +225,8 @@ class LabelStudioTask(ParentModel):
         self.add_annotations(ls_anns)
 
         # For pose: log additional metadata
-        if isinstance(ann, IRPoseImageAnnotation):
+        # If we got back just one annotation, then it's a single point, otherwise it's [bounding box, *points]
+        if isinstance(ann, IRPoseImageAnnotation) and len(ls_anns) > 1:
             bbox = cast(RectangleLabelsAnnotation, ls_anns[0])
             keypoints = cast(List[KeyPointLabelsAnnotation], ls_anns[1:])
             self.log_pose_metadata(bbox, keypoints)
@@ -233,6 +234,12 @@ class LabelStudioTask(ParentModel):
     def add_ir_annotations(self, anns: Sequence[IRImageAnnotationBase]):
         for ann in anns:
             self.add_ir_annotation(ann)
+
+    @staticmethod
+    def from_ir_annotations(anns: Sequence[IRImageAnnotationBase]) -> "LabelStudioTask":
+        res = LabelStudioTask()
+        res.add_ir_annotations(anns)
+        return res
 
 
 def parse_ls_task(task: Union[str, bytes]) -> LabelStudioTask:


### PR DESCRIPTION
Reproduction is pretty much this test case:

```python
def test_add_single_keypoint():
    task = LabelStudioTask()

    task.add_ir_annotation(
        IRPoseImageAnnotation.from_points(
            image_height=200,
            image_width=200,
            categories={"cat": 1.0},
            coordinate_style=CoordinateStyle.NORMALIZED,
            points=[IRPosePoint(x=0.5, y=0.5)],
        )
    )

    assert len(task.annotations[0].result) == 1

    kp = task.annotations[0].result[0]
    assert kp.value.x == 50
    assert kp.value.y == 50
    assert kp.value.keypointlabels == ["cat"]
```

Before this PR, adding a pose annotation with a keypoint also ended up creating a bounding box. This PR makes it so single keypoints don't add these bboxes.