### PR TITLE
Experiment: CVAT Pose grouping by group_id

### DIFF
--- a/.github/workflows/linters-and-test.yml
+++ b/.github/workflows/linters-and-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12, 3.13]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@ annotations = task_obj.to_ir_annotations()
 ## Exporters (Image):
 - [YOLO BBox, Segmentation, Poses](dagshub_annotation_converter/converters/yolo.py#L126)
 - [Label Studio](dagshub_annotation_converter/formats/label_studio/task.py#L225) (Again, only task schema, uploading the task to the project is left to the user)
+
+## Experimental Features:
+
+The package contains some experimental features that can be toggled on by setting a corresponding environment variable:
+
+- `DAGSHUB_ANNOTATION_EXPERIMENTAL_CVAT_POSE_GROUPING_BY_GROUP_ID_ENABLED` - When importing CVAT annotations, 
+you can put a single bbox and either a points or skeletons annotation in a group, and then they will be grouped together
+into a pose annotation. When exporting that to YOLO, the bbox and the points will be exported as a single annotation.
+ 
+You can read more about the features that exist, their limitations and potential side effects
+in the [features.py](dagshub_annotation_converter/features.py) file

--- a/dagshub_annotation_converter/converters/cvat.py
+++ b/dagshub_annotation_converter/converters/cvat.py
@@ -1,14 +1,15 @@
 import logging
+from collections import defaultdict
 from os import PathLike
-from typing import Sequence, List, Dict, Union
+from typing import Sequence, List, Dict, Union, Optional
 from zipfile import ZipFile
 
 import lxml.etree
 
 from dagshub_annotation_converter.formats.cvat import annotation_parsers
 from dagshub_annotation_converter.formats.cvat.context import parse_image_tag
-from dagshub_annotation_converter.ir.image import IRImageAnnotationBase
-
+from dagshub_annotation_converter.ir.image import IRImageAnnotationBase, IRBBoxImageAnnotation, IRPoseImageAnnotation
+from dagshub_annotation_converter.features import ConverterFeatures
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +23,69 @@ def parse_image_annotations(img: lxml.etree.ElementBase) -> Sequence[IRImageAnno
             continue
         annotations.append(annotation_parsers[annotation_type](annotation_elem, img))
 
+    annotations = _maybe_group_poses(annotations)
+
     return annotations
+
+
+def _maybe_group_poses(annotations: List[IRImageAnnotationBase]) -> List[IRImageAnnotationBase]:
+    if not ConverterFeatures.cvat_pose_grouping_by_group_id_enabled():
+        return annotations
+    res = []
+    annotation_groups: Dict[str, List[IRImageAnnotationBase]] = defaultdict(list)
+    for annotation in annotations:
+        group_id = annotation.meta.get("group_id")
+        if group_id is None:
+            res.append(annotation)
+        else:
+            annotation_groups[group_id].append(annotation)
+
+    for group_id, group_annotations in annotation_groups.items():
+        if len(group_annotations) == 1:
+            res.extend(group_annotations)
+            continue
+
+        bbox_count = sum((isinstance(ann, IRBBoxImageAnnotation) for ann in group_annotations))
+        point_count = sum((isinstance(ann, IRPoseImageAnnotation) for ann in group_annotations))
+
+        # If we have more than one bbox or point annotation in the group, don't bother trying to group
+        if bbox_count != 1 or point_count != 1:
+            res.extend(group_annotations)
+            continue
+
+        group_res = []
+        bbox_ann: Optional[IRBBoxImageAnnotation] = None
+        pose_ann: Optional[IRPoseImageAnnotation] = None
+
+        for ann in group_annotations:
+            if isinstance(ann, IRBBoxImageAnnotation):
+                bbox_ann = ann
+            elif isinstance(ann, IRPoseImageAnnotation):
+                pose_ann = ann
+            else:
+                group_res.append(ann)
+
+        assert bbox_ann is not None and pose_ann is not None
+
+        # If there's somehow multiple labels (shouldn't be happening in CVAT), don't group
+        if not (bbox_ann.has_one_category() and pose_ann.has_one_category()):
+            res.extend(group_annotations)
+            continue
+
+        # Different categories - don't group
+        if bbox_ann.ensure_has_one_category() != pose_ann.ensure_has_one_category():
+            res.extend(group_annotations)
+            continue
+
+        pose_ann.width = bbox_ann.width
+        pose_ann.height = bbox_ann.height
+        pose_ann.top = bbox_ann.top
+        pose_ann.left = bbox_ann.left
+
+        group_res.append(pose_ann)
+        res.extend(group_res)
+
+    return res
 
 
 def load_cvat_from_xml_string(

--- a/dagshub_annotation_converter/features.py
+++ b/dagshub_annotation_converter/features.py
@@ -1,0 +1,28 @@
+import os
+from functools import lru_cache
+
+
+FEATURE_CVAT_POSE_GROUPING_KEY = "DAGSHUB_ANNOTATION_EXPERIMENTAL_CVAT_POSE_GROUPING_BY_GROUP_ID_ENABLED"
+
+
+def _is_enabled(key):
+    return os.environ.get(key, "f").lower() in ("true", "1", "t")
+
+
+class ConverterFeatures:
+    @staticmethod
+    @lru_cache
+    def cvat_pose_grouping_by_group_id_enabled() -> bool:
+        """
+        When importing CVAT annotations, groups together pose + bbox, as long as they have the same group_id.
+
+        Limitations:
+        - Only one bbox and one of either points or skeletons annotation per group_id is allowed.
+          If this is not satisfied, then the annotations in the group will be left as is.
+        - bbox and pose need to have the same label
+
+        Side Effects:
+        - Might change the order of annotations in the output.
+        """
+        # return True
+        return _is_enabled(FEATURE_CVAT_POSE_GROUPING_KEY)

--- a/dagshub_annotation_converter/formats/cvat/box.py
+++ b/dagshub_annotation_converter/formats/cvat/box.py
@@ -3,7 +3,7 @@ from typing import Tuple
 
 from lxml.etree import ElementBase
 
-from dagshub_annotation_converter.formats.cvat.context import parse_image_tag
+from dagshub_annotation_converter.formats.cvat.context import parse_image_tag, parse_metadata
 from dagshub_annotation_converter.ir.image import IRBBoxImageAnnotation, CoordinateStyle
 
 
@@ -63,4 +63,5 @@ def parse_box(elem: ElementBase, containing_image: ElementBase) -> IRBBoxImageAn
         image_height=image_info.height,
         filename=image_info.name,
         coordinate_style=CoordinateStyle.DENORMALIZED,
+        meta=parse_metadata(elem),
     )

--- a/dagshub_annotation_converter/formats/cvat/context.py
+++ b/dagshub_annotation_converter/formats/cvat/context.py
@@ -1,3 +1,5 @@
+from typing import Dict, Any
+
 from lxml.etree import ElementBase
 
 from dagshub_annotation_converter.util.pydantic_util import ParentModel
@@ -15,3 +17,11 @@ def parse_image_tag(image: ElementBase) -> CVATImageInfo:
         width=int(image.attrib["width"]),
         height=int(image.attrib["height"]),
     )
+
+
+def parse_metadata(xml: ElementBase) -> Dict[str, Any]:
+    res = {}
+    group_id = xml.attrib.get("group_id")
+    if group_id is not None:
+        res["group_id"] = group_id
+    return res

--- a/dagshub_annotation_converter/formats/cvat/ellipse.py
+++ b/dagshub_annotation_converter/formats/cvat/ellipse.py
@@ -1,6 +1,6 @@
 from lxml.etree import ElementBase
 
-from dagshub_annotation_converter.formats.cvat.context import parse_image_tag
+from dagshub_annotation_converter.formats.cvat.context import parse_image_tag, parse_metadata
 from dagshub_annotation_converter.ir.image import IREllipseImageAnnotation, CoordinateStyle
 
 
@@ -25,4 +25,5 @@ def parse_ellipse(elem: ElementBase, containing_image: ElementBase) -> IREllipse
         image_height=image_info.height,
         filename=image_info.name,
         coordinate_style=CoordinateStyle.DENORMALIZED,
+        meta=parse_metadata(elem),
     )

--- a/dagshub_annotation_converter/formats/cvat/points.py
+++ b/dagshub_annotation_converter/formats/cvat/points.py
@@ -2,7 +2,7 @@ from typing import List
 
 from lxml.etree import ElementBase
 
-from dagshub_annotation_converter.formats.cvat.context import parse_image_tag
+from dagshub_annotation_converter.formats.cvat.context import parse_image_tag, parse_metadata
 from dagshub_annotation_converter.ir.image import IRPoseImageAnnotation, IRPosePoint, CoordinateStyle
 
 
@@ -24,4 +24,5 @@ def parse_points(elem: ElementBase, containing_image: ElementBase) -> IRPoseImag
         image_width=image_info.width,
         image_height=image_info.height,
         filename=image_info.name,
+        meta=parse_metadata(elem),
     )

--- a/dagshub_annotation_converter/formats/cvat/polygon.py
+++ b/dagshub_annotation_converter/formats/cvat/polygon.py
@@ -1,6 +1,6 @@
 from lxml.etree import ElementBase
 
-from dagshub_annotation_converter.formats.cvat.context import parse_image_tag
+from dagshub_annotation_converter.formats.cvat.context import parse_image_tag, parse_metadata
 from dagshub_annotation_converter.ir.image import IRSegmentationImageAnnotation, CoordinateStyle
 
 
@@ -15,6 +15,7 @@ def parse_polygon(elem: ElementBase, containing_image: ElementBase) -> IRSegment
         image_width=image_info.width,
         image_height=image_info.height,
         filename=image_info.name,
+        meta=parse_metadata(elem),
     )
 
     for point_str in elem.attrib["points"].split(";"):

--- a/dagshub_annotation_converter/formats/cvat/skeleton.py
+++ b/dagshub_annotation_converter/formats/cvat/skeleton.py
@@ -2,7 +2,7 @@ from typing import Tuple, List
 
 from lxml.etree import ElementBase
 
-from dagshub_annotation_converter.formats.cvat.context import parse_image_tag
+from dagshub_annotation_converter.formats.cvat.context import parse_image_tag, parse_metadata
 from dagshub_annotation_converter.ir.image import IRPoseImageAnnotation, IRPosePoint, CoordinateStyle
 
 
@@ -40,4 +40,5 @@ def parse_skeleton(elem: ElementBase, containing_image: ElementBase) -> IRPoseIm
         image_width=image_info.width,
         image_height=image_info.height,
         filename=image_info.name,
+        meta=parse_metadata(elem),
     )

--- a/dagshub_annotation_converter/ir/image/annotations/base.py
+++ b/dagshub_annotation_converter/ir/image/annotations/base.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Optional, Dict
+from typing import Optional, Dict, Any
 
 from typing_extensions import Self
 
@@ -32,6 +32,7 @@ class IRAnnotationBase(ParentModel):
     """Categories and their confidence. 1 means 100% confidence or ground truth."""
     coordinate_style: CoordinateStyle
     imported_id: Optional[str] = None
+    meta: Dict[str, Any] = {}
 
     def with_filename(self, filename: str) -> Self:
         self.filename = filename

--- a/dagshub_annotation_converter/ir/image/annotations/pose.py
+++ b/dagshub_annotation_converter/ir/image/annotations/pose.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, TYPE_CHECKING, Dict
+from typing import List, Optional, TYPE_CHECKING, Dict, Any
 
 from dagshub_annotation_converter.ir.image.annotations.base import IRImageAnnotationBase
 from dagshub_annotation_converter.util.pydantic_util import ParentModel
@@ -53,6 +53,7 @@ class IRPoseImageAnnotation(IRImageAnnotationBase):
         image_width: int,
         image_height: int,
         filename: Optional[str] = None,
+        meta: Optional[Dict[str, Any]] = None,
     ) -> "IRPoseImageAnnotation":
         point_xs = list(map(lambda p: p.x, points))
         point_ys = list(map(lambda p: p.y, points))
@@ -73,4 +74,5 @@ class IRPoseImageAnnotation(IRImageAnnotationBase):
             coordinate_style=coordinate_style,
             image_height=image_height,
             image_width=image_width,
+            meta=meta or {},
         )

--- a/tests/cvat/res/pose_grouping.xml
+++ b/tests/cvat/res/pose_grouping.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<annotations>
+  <version>1.1</version>
+  <meta>
+    <task>
+      <id>1</id>
+      <name>babyyoda</name>
+      <size>7</size>
+      <mode>annotation</mode>
+      <overlap>0</overlap>
+      <bugtracker></bugtracker>
+      <created>2025-07-13 12:09:41.683169+00:00</created>
+      <updated>2025-07-17 09:12:31.887619+00:00</updated>
+      <subset>default</subset>
+      <start_frame>0</start_frame>
+      <stop_frame>6</stop_frame>
+      <frame_filter></frame_filter>
+      <segments>
+        <segment>
+          <id>1</id>
+          <start>0</start>
+          <stop>6</stop>
+          <url>http://localhost:8082/api/jobs/1</url>
+        </segment>
+      </segments>
+      <owner>
+        <username>kirill</username>
+        <email>kirill@example.com</email>
+      </owner>
+      <assignee></assignee>
+      <labels>
+        <label>
+          <name>Pointy</name>
+          <color>#412ab3</color>
+          <type>points</type>
+          <attributes>
+          </attributes>
+        </label>
+        <label>
+          <name>Skelly</name>
+          <color>#2faa43</color>
+          <type>skeleton</type>
+          <attributes>
+          </attributes>
+          <svg>&lt;circle r="0.75" cx="22.240802764892578" cy="21.97881317138672" data-type="element node" data-element-id="1" data-node-id="1" data-label-name="1"&gt;&lt;/circle&gt;
+&lt;circle r="0.75" cx="70.56856536865234" cy="20.975467681884766" data-type="element node" data-element-id="2" data-node-id="2" data-label-name="2"&gt;&lt;/circle&gt;
+&lt;circle r="0.75" cx="50" cy="42.04570388793945" data-type="element node" data-element-id="3" data-node-id="3" data-label-name="3"&gt;&lt;/circle&gt;
+&lt;circle r="0.75" cx="35.785953521728516" cy="69.47045135498047" data-type="element node" data-element-id="4" data-node-id="4" data-label-name="4"&gt;&lt;/circle&gt;
+&lt;circle r="0.75" cx="76.75585174560547" cy="75.49051666259766" data-type="element node" data-element-id="5" data-node-id="5" data-label-name="5"&gt;&lt;/circle&gt;</svg>
+        </label>
+        <label>
+          <name>1</name>
+          <color>#d12345</color>
+          <type>points</type>
+          <attributes>
+          </attributes>
+          <parent>Skelly</parent>
+        </label>
+        <label>
+          <name>2</name>
+          <color>#350dea</color>
+          <type>points</type>
+          <attributes>
+          </attributes>
+          <parent>Skelly</parent>
+        </label>
+        <label>
+          <name>3</name>
+          <color>#479ffe</color>
+          <type>points</type>
+          <attributes>
+          </attributes>
+          <parent>Skelly</parent>
+        </label>
+        <label>
+          <name>4</name>
+          <color>#4a649f</color>
+          <type>points</type>
+          <attributes>
+          </attributes>
+          <parent>Skelly</parent>
+        </label>
+        <label>
+          <name>5</name>
+          <color>#478144</color>
+          <type>points</type>
+          <attributes>
+          </attributes>
+          <parent>Skelly</parent>
+        </label>
+        <label>
+          <name>Pointy_Box</name>
+          <color>#3df53d</color>
+          <type>rectangle</type>
+          <attributes>
+          </attributes>
+        </label>
+      </labels>
+    </task>
+    <dumped>2025-07-17 09:12:42.948722+00:00</dumped>
+  </meta>
+  <image id="0" name="000.png" width="1920" height="1200">
+    <box label="Pointy_1" source="manual" occluded="0" xtl="722.19" ytl="272.64" xbr="1045.57" ybr="614.93" z_order="0" group_id="1">
+    </box>
+    <points label="Pointy_1" source="manual" occluded="0" points="818.71,421.89;880.40,419.90;838.61,461.69;851.54,538.31;786.87,342.29;899.90,335.92" z_order="0" group_id="1">
+    </points>
+    <points label="Pointy_2" source="manual" occluded="0" points="206.32,657.31;350.60,648.19;261.04,731.11;370.50,732.77" z_order="0" group_id="2">
+    </points>
+    <box label="Pointy_2" source="manual" occluded="0" xtl="151.59" ytl="624.98" xbr="431.03" ybr="800.76" z_order="0" group_id="2">
+    </box>
+    <box label="Pointy_2" source="manual" occluded="0" xtl="155.59" ytl="625.98" xbr="431.03" ybr="800.76" z_order="0" group_id="2">
+    </box>
+    <skeleton label="Pointy_3" source="manual" z_order="0" group_id="3">
+      <points label="1" source="manual" outside="0" occluded="0" points="1428.08,667.88" group_id="3">
+      </points>
+      <points label="2" source="manual" outside="0" occluded="0" points="1561.54,666.88" group_id="3">
+      </points>
+      <points label="3" source="manual" outside="0" occluded="0" points="1490.16,727.74" group_id="3">
+      </points>
+      <points label="4" source="manual" outside="0" occluded="0" points="1437.35,831.88" group_id="3">
+      </points>
+      <points label="5" source="manual" outside="0" occluded="0" points="1508.13,829.78" group_id="3">
+      </points>
+    </skeleton>
+    <box label="Pointy_3" source="manual" occluded="0" xtl="1337.91" ytl="602.29" xbr="1645.27" ybr="958.51" z_order="0" group_id="3">
+    </box>
+    <box label="Pointy_misc" source="manual" occluded="0" xtl="179.70" ytl="284.88" xbr="547.76" ybr="429.15" z_order="0">
+    </box>
+    <skeleton label="Pointy_misc" source="manual" z_order="0">
+      <points label="1" source="manual" outside="0" occluded="0" points="853.23,756.73">
+      </points>
+      <points label="2" source="manual" outside="0" occluded="0" points="992.60,752.54">
+      </points>
+      <points label="3" source="manual" outside="0" occluded="0" points="933.29,840.61">
+      </points>
+      <points label="4" source="manual" outside="0" occluded="0" points="892.30,955.24">
+      </points>
+      <points label="5" source="manual" outside="0" occluded="0" points="1010.45,980.40">
+      </points>
+    </skeleton>
+    <points label="Pointy_misc" source="manual" occluded="0" points="1429.65,334.33;1702.29,320.40;1568.95,457.71;1737.11,428.86" z_order="0">
+    </points>
+  </image>
+</annotations>

--- a/tests/cvat/test_pose_grouping.py
+++ b/tests/cvat/test_pose_grouping.py
@@ -1,0 +1,42 @@
+from collections import defaultdict
+from pathlib import Path
+from typing import List, Dict, Sequence
+
+from dagshub_annotation_converter.converters.cvat import load_cvat_from_xml_file
+from dagshub_annotation_converter.features import FEATURE_CVAT_POSE_GROUPING_KEY
+from dagshub_annotation_converter.ir.image import IRPoseImageAnnotation, IRBBoxImageAnnotation
+from dagshub_annotation_converter.ir.image.annotations.base import IRAnnotationBase
+from tests.util import set_env_var
+
+_filepath = Path(__file__).parent / "res/pose_grouping.xml"
+
+
+def test_pose_grouping():
+    with set_env_var(FEATURE_CVAT_POSE_GROUPING_KEY, "t"):
+        annotations = load_cvat_from_xml_file(_filepath)["000.png"]
+
+        categorized = _group_by_category(annotations)
+
+        # Pointy_1 - good case (bbox + points)
+        assert len(categorized["Pointy_1"]) == 1
+        assert isinstance(categorized["Pointy_1"][0], IRPoseImageAnnotation)
+
+        # Pointy_2 - has multiple bboxes, should not be grouped
+        assert len(categorized["Pointy_2"]) == 3
+        assert any(isinstance(ann, IRPoseImageAnnotation) for ann in categorized["Pointy_2"])
+        assert any(isinstance(ann, IRBBoxImageAnnotation) for ann in categorized["Pointy_2"])
+
+        # Pointy_3 - good case (bbox + skeleton)
+        assert len(categorized["Pointy_3"]) == 1
+        assert isinstance(categorized["Pointy_3"][0], IRPoseImageAnnotation)
+
+        # Pointy_misc - the rest, should be 3 annotations
+        assert len(categorized["Pointy_misc"]) == 3
+
+
+def _group_by_category(annotations: Sequence[IRAnnotationBase]) -> Dict[str, List[IRAnnotationBase]]:
+    grouped = defaultdict(list)
+    for annotation in annotations:
+        category = annotation.ensure_has_one_category()
+        grouped[category].append(annotation)
+    return grouped

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,21 @@
+import os
+
+
+class set_env_var:
+    def __init__(self, key, value):
+        self.key = key
+        self.value = value
+        self._old_value = None
+        self._had_old = False
+
+    def __enter__(self):
+        self._had_old = self.key in os.environ
+        if self._had_old:
+            self._old_value = os.environ[self.key]
+        os.environ[self.key] = self.value
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._had_old:
+            os.environ[self.key] = self._old_value
+        else:
+            del os.environ[self.key]


### PR DESCRIPTION
Experimental feature hidden behind an env var toggle `DAGSHUB_ANNOTATION_EXPERIMENTAL_CVAT_POSE_GROUPING_BY_GROUP_ID_ENABLED`.

After this PR, if the env var is set to true and grouping together a bounding box and pose/skeleton like this:
```xml
<box label="Pointy_1" source="manual" occluded="0" 
xtl="722.19" ytl="272.64" xbr="1045.57" ybr="614.93" z_order="0" 
group_id="1">
</box>
<points label="Pointy_1" source="manual" occluded="0" 
points="818.71,421.89;880.40,419.90;838.61,461.69;851.54,538.31;786.87,342.29;899.90,335.92" z_order="0" 
group_id="1">
</points>
```

Before: Creates a BBox annotation and a separate Pose annotation from points, that have BBox be around the points
Now: Creates a single Pose annotation, with the BBox being the `<box>` one

Constraints:
- Doesn't group if there are more than 1 bbox or points/skeletons annotation in the group
- Doesn't group if the label of the bbox doesn't match the label of points/skeletons

As a side effect, this might change the order in which annotations are imported from CVAT.