### PR TITLE
Bug/fix path handling for windows

### DIFF
--- a/dagshub_annotation_converter/converters/yolo.py
+++ b/dagshub_annotation_converter/converters/yolo.py
@@ -35,7 +35,7 @@ def load_yolo_from_fs_with_context(
         data_dir_path = import_dir_path / context.path
 
     for dirpath, subdirs, files in os.walk(data_dir_path):
-        if context.image_dir_name not in dirpath.split("/"):
+        if context.image_dir_name not in Path(dirpath).parts:
             logger.debug(f"{dirpath} is not an image dir, skipping")
             continue
         for filename in files:

--- a/dagshub_annotation_converter/formats/yolo/context.py
+++ b/dagshub_annotation_converter/formats/yolo/context.py
@@ -30,7 +30,7 @@ class YoloContext(ParentModel):
     image_dir_name: str = "images"
     """Name of the directory containing image files"""
     keypoint_dim: Literal[2, 3] = 3
-    """[For pose annotations] 
+    """[For pose annotations]
     Dimension of the annotation: 2 - x, y; 3 - x, y, visibility"""
     keypoints_in_annotation: Optional[int] = None
     """[For pose annotations]


### PR DESCRIPTION
## Spec
* When running in windows, `dirpath` can be `c:\some\path\dir`, and therefore splitting the parts doesn't work with string manipulation.
* Use `Path.parts` instead.