### PR TITLE
Parse CVAT extras, propagate them to LS meta dictionary

### DIFF
--- a/dagshub_annotation_converter/formats/cvat/box.py
+++ b/dagshub_annotation_converter/formats/cvat/box.py
@@ -6,6 +6,8 @@ from lxml.etree import ElementBase
 from dagshub_annotation_converter.formats.cvat.context import parse_image_tag, parse_metadata
 from dagshub_annotation_converter.ir.image import IRBBoxImageAnnotation, CoordinateStyle
 
+_keys = {"xtl", "ytl", "xbr", "ybr", "rotation", "label"}
+
 
 def calculate_bbox(xtl, ytl, xbr, ybr, rotation: float) -> Tuple[int, int, int, int, float]:
     """
@@ -63,5 +65,5 @@ def parse_box(elem: ElementBase, containing_image: ElementBase) -> IRBBoxImageAn
         image_height=image_info.height,
         filename=image_info.name,
         coordinate_style=CoordinateStyle.DENORMALIZED,
-        meta=parse_metadata(elem),
+        meta=parse_metadata(elem, _keys),
     )

--- a/dagshub_annotation_converter/formats/cvat/context.py
+++ b/dagshub_annotation_converter/formats/cvat/context.py
@@ -19,9 +19,9 @@ def parse_image_tag(image: ElementBase) -> CVATImageInfo:
     )
 
 
-def parse_metadata(xml: ElementBase) -> Dict[str, Any]:
+def parse_metadata(xml: ElementBase, reserved_keys: set[str]) -> Dict[str, Any]:
     res = {}
-    group_id = xml.attrib.get("group_id")
-    if group_id is not None:
-        res["group_id"] = group_id
+    for key, value in xml.attrib.items():
+        if key not in reserved_keys:
+            res[key] = value
     return res

--- a/dagshub_annotation_converter/formats/cvat/ellipse.py
+++ b/dagshub_annotation_converter/formats/cvat/ellipse.py
@@ -3,6 +3,8 @@ from lxml.etree import ElementBase
 from dagshub_annotation_converter.formats.cvat.context import parse_image_tag, parse_metadata
 from dagshub_annotation_converter.ir.image import IREllipseImageAnnotation, CoordinateStyle
 
+_keys = {"cx", "cy", "rx", "ry", "rotation", "label"}
+
 
 def parse_ellipse(elem: ElementBase, containing_image: ElementBase) -> IREllipseImageAnnotation:
     center_x = float(elem.attrib["cx"])
@@ -25,5 +27,5 @@ def parse_ellipse(elem: ElementBase, containing_image: ElementBase) -> IREllipse
         image_height=image_info.height,
         filename=image_info.name,
         coordinate_style=CoordinateStyle.DENORMALIZED,
-        meta=parse_metadata(elem),
+        meta=parse_metadata(elem, _keys),
     )

--- a/dagshub_annotation_converter/formats/cvat/points.py
+++ b/dagshub_annotation_converter/formats/cvat/points.py
@@ -5,6 +5,8 @@ from lxml.etree import ElementBase
 from dagshub_annotation_converter.formats.cvat.context import parse_image_tag, parse_metadata
 from dagshub_annotation_converter.ir.image import IRPoseImageAnnotation, IRPosePoint, CoordinateStyle
 
+_keys = {"label", "points"}
+
 
 def parse_points(elem: ElementBase, containing_image: ElementBase) -> IRPoseImageAnnotation:
     points: List[IRPosePoint] = []
@@ -24,5 +26,5 @@ def parse_points(elem: ElementBase, containing_image: ElementBase) -> IRPoseImag
         image_width=image_info.width,
         image_height=image_info.height,
         filename=image_info.name,
-        meta=parse_metadata(elem),
+        meta=parse_metadata(elem, _keys),
     )

--- a/dagshub_annotation_converter/formats/cvat/polygon.py
+++ b/dagshub_annotation_converter/formats/cvat/polygon.py
@@ -3,6 +3,8 @@ from lxml.etree import ElementBase
 from dagshub_annotation_converter.formats.cvat.context import parse_image_tag, parse_metadata
 from dagshub_annotation_converter.ir.image import IRSegmentationImageAnnotation, CoordinateStyle
 
+_keys = {"label", "points"}
+
 
 def parse_polygon(elem: ElementBase, containing_image: ElementBase) -> IRSegmentationImageAnnotation:
     category = str(elem.attrib["label"])
@@ -15,7 +17,7 @@ def parse_polygon(elem: ElementBase, containing_image: ElementBase) -> IRSegment
         image_width=image_info.width,
         image_height=image_info.height,
         filename=image_info.name,
-        meta=parse_metadata(elem),
+        meta=parse_metadata(elem, _keys),
     )
 
     for point_str in elem.attrib["points"].split(";"):

--- a/dagshub_annotation_converter/formats/cvat/skeleton.py
+++ b/dagshub_annotation_converter/formats/cvat/skeleton.py
@@ -5,6 +5,8 @@ from lxml.etree import ElementBase
 from dagshub_annotation_converter.formats.cvat.context import parse_image_tag, parse_metadata
 from dagshub_annotation_converter.ir.image import IRPoseImageAnnotation, IRPosePoint, CoordinateStyle
 
+_keys = {"label", "points", "occluded"}
+
 
 def parse_skeleton(elem: ElementBase, containing_image: ElementBase) -> IRPoseImageAnnotation:
     # Points also contain the labels, for consistent ordering in LS, they are later sorted
@@ -40,5 +42,5 @@ def parse_skeleton(elem: ElementBase, containing_image: ElementBase) -> IRPoseIm
         image_width=image_info.width,
         image_height=image_info.height,
         filename=image_info.name,
-        meta=parse_metadata(elem),
+        meta=parse_metadata(elem, _keys),
     )

--- a/dagshub_annotation_converter/formats/label_studio/base.py
+++ b/dagshub_annotation_converter/formats/label_studio/base.py
@@ -1,6 +1,6 @@
 import uuid
 from abc import abstractmethod
-from typing import Sequence, Optional
+from typing import Sequence, Optional, Any
 
 from pydantic import Field
 
@@ -39,6 +39,7 @@ class ImageAnnotationResultABC(AnnotationResultABC):
     from_name: str = "label"
     score: Optional[float] = None
     """For predictions, the score of the prediction."""
+    meta: Optional[dict[str, Any]] = None
 
     @abstractmethod
     def to_ir_annotation(self) -> Sequence[IRImageAnnotationBase]:

--- a/dagshub_annotation_converter/formats/label_studio/ellipselabels.py
+++ b/dagshub_annotation_converter/formats/label_studio/ellipselabels.py
@@ -29,6 +29,7 @@ class EllipseLabelsAnnotation(ImageAnnotationResultABC):
             rotation=self.value.rotation,
             image_width=self.original_width,
             image_height=self.original_height,
+            meta=self.meta or {},
         )
         res.imported_id = self.id
         return [res]
@@ -52,5 +53,6 @@ class EllipseLabelsAnnotation(ImageAnnotationResultABC):
                     rotation=ir_annotation.rotation,
                     ellipselabels=[category],
                 ),
+                meta=ir_annotation.meta or None,
             )
         ]

--- a/dagshub_annotation_converter/formats/label_studio/keypointlabels.py
+++ b/dagshub_annotation_converter/formats/label_studio/keypointlabels.py
@@ -32,6 +32,7 @@ class KeyPointLabelsAnnotation(ImageAnnotationResultABC):
             coordinate_style=CoordinateStyle.NORMALIZED,
             image_width=self.original_width,
             image_height=self.original_height,
+            meta=self.meta or {},
         )
         ann.imported_id = self.id
         return [ann]
@@ -57,6 +58,7 @@ class KeyPointLabelsAnnotation(ImageAnnotationResultABC):
                     height=ir_annotation.height * 100,
                     rectanglelabels=[category],
                 ),
+                meta=ir_annotation.meta or None,
             )
             res.append(bbox)
 
@@ -70,6 +72,7 @@ class KeyPointLabelsAnnotation(ImageAnnotationResultABC):
                         y=point.y * 100,
                         keypointlabels=[category],
                     ),
+                    meta=ir_annotation.meta or None,
                 )
             )
 

--- a/dagshub_annotation_converter/formats/label_studio/polygonlabels.py
+++ b/dagshub_annotation_converter/formats/label_studio/polygonlabels.py
@@ -21,6 +21,7 @@ class PolygonLabelsAnnotation(ImageAnnotationResultABC):
             coordinate_style=CoordinateStyle.NORMALIZED,
             image_width=self.original_width,
             image_height=self.original_height,
+            meta=self.meta or {},
         )
         for p in self.value.points:
             res.add_point(p[0] / 100, p[1] / 100)
@@ -42,5 +43,6 @@ class PolygonLabelsAnnotation(ImageAnnotationResultABC):
                     points=[[p.x * 100, p.y * 100] for p in ir_annotation.points],
                     polygonlabels=[category],
                 ),
+                meta=ir_annotation.meta or None,
             )
         ]

--- a/dagshub_annotation_converter/formats/label_studio/rectanglelabels.py
+++ b/dagshub_annotation_converter/formats/label_studio/rectanglelabels.py
@@ -29,6 +29,7 @@ class RectangleLabelsAnnotation(ImageAnnotationResultABC):
             rotation=self.value.rotation,
             image_width=self.original_width,
             image_height=self.original_height,
+            meta=self.meta or {},
         )
         res.imported_id = self.id
         return [res]
@@ -52,5 +53,6 @@ class RectangleLabelsAnnotation(ImageAnnotationResultABC):
                     rotation=ir_annotation.rotation,
                     rectanglelabels=[category],
                 ),
+                meta=ir_annotation.meta or None,
             )
         ]

--- a/tests/cvat/test_extras.py
+++ b/tests/cvat/test_extras.py
@@ -1,0 +1,54 @@
+import pprint
+
+import pytest
+
+from dagshub_annotation_converter.formats.cvat import parse_ellipse
+from dagshub_annotation_converter.formats.label_studio.task import LabelStudioTask
+from dagshub_annotation_converter.ir.image import IREllipseImageAnnotation, CoordinateStyle
+from tests.cvat.test_parsers import to_xml
+
+
+@pytest.fixture()
+def cvat_ellipse():
+    data = """
+    <ellipse label="circle1" source="manual" occluded="0" cx="392.23" cy="322.84" rx="205.06" ry="202.84" z_order="0" 
+        group_id="1" foo="bar">
+    </ellipse> 
+    """
+
+    image, annotation = to_xml(data)
+    return parse_ellipse(annotation, image)
+
+
+def test_extra_values(cvat_ellipse):
+    expected = IREllipseImageAnnotation(
+        filename="000.png",
+        categories={"circle1": 1.0},
+        image_width=1920,
+        image_height=1200,
+        coordinate_style=CoordinateStyle.DENORMALIZED,
+        center_x=392,
+        center_y=323,
+        radius_x=205.06,
+        radius_y=202.84,
+        rotation=0.0,
+        meta={"group_id": "1", "foo": "bar", "source": "manual", "occluded": "0", "z_order": "0"},
+    )
+
+    assert cvat_ellipse == expected
+
+
+def test_extras_persist_in_labelstudio(cvat_ellipse):
+    ls_task = LabelStudioTask()
+    ls_task.add_ir_annotation(cvat_ellipse)
+    task_dump = ls_task.model_dump()
+    print()
+    pprint.pprint(task_dump)
+    meta = task_dump["annotations"][0]["result"][0].get("meta")
+    assert meta == {
+        "group_id": "1",
+        "foo": "bar",
+        "source": "manual",
+        "occluded": "0",
+        "z_order": "0",
+    }

--- a/tests/cvat/test_extras.py
+++ b/tests/cvat/test_extras.py
@@ -1,5 +1,3 @@
-import pprint
-
 import pytest
 
 from dagshub_annotation_converter.formats.cvat import parse_ellipse
@@ -42,8 +40,6 @@ def test_extras_persist_in_labelstudio(cvat_ellipse):
     ls_task = LabelStudioTask()
     ls_task.add_ir_annotation(cvat_ellipse)
     task_dump = ls_task.model_dump()
-    print()
-    pprint.pprint(task_dump)
     meta = task_dump["annotations"][0]["result"][0].get("meta")
     assert meta == {
         "group_id": "1",

--- a/tests/cvat/test_parsers.py
+++ b/tests/cvat/test_parsers.py
@@ -7,7 +7,8 @@ from dagshub_annotation_converter.formats.cvat import (
     parse_box,
     parse_polygon,
     parse_points,
-    parse_skeleton, parse_ellipse,
+    parse_skeleton,
+    parse_ellipse,
 )
 from dagshub_annotation_converter.ir.image import (
     CoordinateStyle,
@@ -15,7 +16,8 @@ from dagshub_annotation_converter.ir.image import (
     IRSegmentationImageAnnotation,
     IRSegmentationPoint,
     IRPosePoint,
-    IRPoseImageAnnotation, IREllipseImageAnnotation,
+    IRPoseImageAnnotation,
+    IREllipseImageAnnotation,
 )
 
 
@@ -36,6 +38,7 @@ def test_box():
     image, annotation = to_xml(data)
 
     actual = parse_box(annotation, image)
+    actual.meta = {}
 
     expected = IRBBoxImageAnnotation(
         filename="000.png",
@@ -63,6 +66,7 @@ def test_segmentation():
     image, annotation = to_xml(data)
 
     actual = parse_polygon(annotation, image)
+    actual.meta = {}
 
     expected_points = []
     points = (
@@ -95,6 +99,7 @@ def test_points():
     image, annotation = to_xml(data)
 
     actual = parse_points(annotation, image)
+    actual.meta = {}
 
     expected_points = [
         IRPosePoint(x=697.51, y=665.77),
@@ -137,6 +142,7 @@ def test_skeleton():
     image, annotation = to_xml(data)
 
     actual = parse_skeleton(annotation, image)
+    actual.meta = {}
 
     # NOTE: order is important here!
     expected_points = [
@@ -170,6 +176,7 @@ def test_ellipse():
     image, annotation = to_xml(data)
 
     actual = parse_ellipse(annotation, image)
+    actual.meta = {}
 
     expected = IREllipseImageAnnotation(
         filename="000.png",


### PR DESCRIPTION
Make the extra values from CVAT annotations show up in the LabelStudio annotation in a `meta` dictionary. That way any extra things the users want to persist (like group IDs) will be kept in the LS annotation