### PR TITLE
Infra: Run hatch test with the right python version

### DIFF
--- a/.github/workflows/linters-and-test.yml
+++ b/.github/workflows/linters-and-test.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Install Hatch
         run: pipx install hatch
       - name: Run tests
-        run: hatch test
+        run: hatch test -i python=${{ matrix.python-version }}

--- a/.github/workflows/linters-and-test.yml
+++ b/.github/workflows/linters-and-test.yml
@@ -17,14 +17,14 @@ jobs:
 
   run-tests:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12, 3.13]
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        python-version: [3.8, 3.9, "3.10", 3.11, 3.12, 3.13]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
       - name: Install Hatch
-        run: pipx install hatch && hatch env prune
+        run: pipx install hatch
       - name: Run tests
-        run: hatch test -py ${{ matrix.python-version }}
+        run: hatch test -a

--- a/.github/workflows/linters-and-test.yml
+++ b/.github/workflows/linters-and-test.yml
@@ -17,14 +17,14 @@ jobs:
 
   run-tests:
     runs-on: ubuntu-latest
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        python-version: [3.8, 3.9, "3.10", 3.11, 3.12, 3.13]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12, 3.13]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
       - name: Install Hatch
         run: pipx install hatch
       - name: Run tests
-        run: hatch test -a
+        run: hatch test -py ${{ matrix.python-version }}

--- a/.github/workflows/linters-and-test.yml
+++ b/.github/workflows/linters-and-test.yml
@@ -25,6 +25,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
       - name: Install Hatch
-        run: pipx install hatch
+        run: pipx install hatch && hatch python install ${{ matrix.python-version }}
       - name: Run tests
         run: hatch test -py ${{ matrix.python-version }}

--- a/.github/workflows/linters-and-test.yml
+++ b/.github/workflows/linters-and-test.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Install Hatch
         run: pipx install hatch
       - name: Run tests
-        run: hatch test -i python="${{ matrix.python-version }}"
+        run: hatch test -py ${{ matrix.python-version }}

--- a/.github/workflows/linters-and-test.yml
+++ b/.github/workflows/linters-and-test.yml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-        with:
-            python-version: ${{ matrix.python-version }}
       - name: Install Hatch
         run: pipx install hatch
       - name: Run tests

--- a/.github/workflows/linters-and-test.yml
+++ b/.github/workflows/linters-and-test.yml
@@ -25,6 +25,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
       - name: Install Hatch
-        run: pipx install hatch && hatch python install ${{ matrix.python-version }}
+        run: pipx install hatch && hatch env prune
       - name: Run tests
         run: hatch test -py ${{ matrix.python-version }}

--- a/.github/workflows/linters-and-test.yml
+++ b/.github/workflows/linters-and-test.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Install Hatch
         run: pipx install hatch
       - name: Run tests
-        run: hatch test -i python=${{ matrix.python-version }}
+        run: hatch test -i python="${{ matrix.python-version }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.types]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
   "ultralytics",
 ]
 
-[[tool.hatch.envs.all.matrix]]
+[[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.types]


### PR DESCRIPTION
Right now `hatch test` doesn't respect the python-version variable from the matrix, so "Python 3.8" tests actually ran with Python 3.12
This PR makes sure it's being run in a correct environment.
Example: https://github.com/DagsHub/dagshub-annotation-converter/actions/runs/21562804831/job/62129400798